### PR TITLE
Fix XSS vulnerability when creating a channel

### DIFF
--- a/index.html
+++ b/index.html
@@ -418,12 +418,15 @@
                 if ( isError ) {
                     showToast( `${t('unknownError')}` );
                 } else {
-                    var picture = 
+                    const idPurified = DOMPurify.sanitize( event.id, { USE_PROFILES: { html: false, xml: false, svgFilters: false, mathMl: false } });
+                    const picPurified = DOMPurify.sanitize( JSON.parse( content )[ "picture" ], { USE_PROFILES: { html: false, xml: false, svgFilters: false, mathMl: false } } );
+                    const namePurified = DOMPurify.sanitize( JSON.parse( content )[ "name" ], { USE_PROFILES: { html: false, xml: false, svgFilters: false, mathMl: false } } );
+                    var picture =
                     document.getElementsByClassName( "removable-channels" )[ 0 ].innerHTML += `
                             <div class="removable-channel ${event.id}">
-                                <span class="x-circle" onclick="removeChannel( '${event.id}' )">&times;</span>
-                                <span class="img-circle" style="background-image: url('${JSON.parse( content )[ "picture" ]}')"></span>
-                                <span class="removable-channel-name">${JSON.parse( content )[ "name" ]}</span>
+                                <span class="x-circle" onclick="removeChannel( '${idPurified}' )">&times;</span>
+                                <span class="img-circle" style="background-image: url('${picPurified}')"></span>
+                                <span class="removable-channel-name">${namePurified}</span>
                                 <div style="clear: both"></div>
                             </div>
                     `;


### PR DESCRIPTION
When you create a new channel, there's code that adds the channel to the channel administration list.
The data of the channel is taken directly from the event that was retrieved from the relay, without any sanitation.

Furthermore, as relays can easy read Anigma's fingerprint by looking at the subscription ids (leading zeroes), a malicious relay could trivially target and attack Anigma users.
I don't consider this attack purely theoretical. 

Not entirely sure about this one (but pretty sure); it doesn't actually look like you even need to create a channel in order to trigger the vulnerability. The relay could just send out an event with a faux subscription ID (as there's no check if the subscription actually exists).

A friendly Christmas salute
Hampus